### PR TITLE
Hotfix for 0.15: Do not restrict the DropItems ItemRefs to an XJDF Resource

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,14 +35,14 @@ configurations {
 repositories {
     maven { url "https://repository.apache.org/content/groups/public/" }
     maven { url "https://repository.jboss.org/nexus/content/groups/public-jboss/" }
-    maven { url "http://repo.maven.apache.org/maven2" }
+    maven { url "https://repo.maven.apache.org/maven2" }
 }
 dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8'
     compile group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0.1'
     compile group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0.1'
-    compile group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-runtime', version: '0.9.1'
+    compile group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-runtime', version: '0.12.0'
     compile group: 'org.jetbrains', name: 'annotations', version: '15.0'
     compile group: 'org.reflections', name: 'reflections', version: '0.9.11'
 
@@ -58,8 +58,8 @@ dependencies {
     xjc group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0.1'
     xjc group: 'com.sun.xml.bind', name: 'jaxb-xjc', version: '2.2.11'
     xjc group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0.1'
-    xjc group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics', version: '0.9.5'
-    xjc group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-ant', version: '0.9.5'
+    xjc group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics', version: '0.12.0'
+    xjc group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-ant', version: '0.12.0'
     xjc group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-fluent-api', version: '3.0'
 }
 
@@ -126,12 +126,12 @@ jar {
     dependsOn createBuildInfoFile
     manifest {
         attributes(
-            "Implementation-Title": project.description,
-            "Implementation-Version": project.version,
-            "Implementation-Vendor-Id": project.group,
-            "Specification-Title": project.description,
-            "Specification-Version": project.version,
-            "Build-Jdk": JavaVersion.current(),
+                "Implementation-Title": project.description,
+                "Implementation-Version": project.version,
+                "Implementation-Vendor-Id": project.group,
+                "Specification-Title": project.description,
+                "Specification-Version": project.version,
+                "Build-Jdk": JavaVersion.current(),
         )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -126,12 +126,12 @@ jar {
     dependsOn createBuildInfoFile
     manifest {
         attributes(
-                "Implementation-Title": project.description,
-                "Implementation-Version": project.version,
-                "Implementation-Vendor-Id": project.group,
-                "Specification-Title": project.description,
-                "Specification-Version": project.version,
-                "Build-Jdk": JavaVersion.current(),
+            "Implementation-Title": project.description,
+            "Implementation-Version": project.version,
+            "Implementation-Vendor-Id": project.group,
+            "Specification-Title": project.description,
+            "Specification-Version": project.version,
+            "Build-Jdk": JavaVersion.current(),
         )
     }
 }

--- a/src/main/java/org/cip4/lib/xjdf/type/Matrix.java
+++ b/src/main/java/org/cip4/lib/xjdf/type/Matrix.java
@@ -1,5 +1,7 @@
 package org.cip4.lib.xjdf.type;
 
+import java.util.Locale;
+
 /**
  * Coordinate transformation matrices are widely used throughout the whole printing Process, especially in Layout
  * Resources. They represent two dimensional
@@ -160,7 +162,7 @@ public class Matrix extends AbstractXJdfType<String, Matrix> {
         double tx = matrix.getTx();
         double ty = matrix.getTy();
 
-        return String.format("%s %s %s %s %s %s", a, b, c, d, tx, ty);
+        return String.format(Locale.US, "%s %s %s %s %s %s", a, b, c, d, tx, ty);
     }
 
     /**

--- a/src/main/java/org/cip4/lib/xjdf/type/Rectangle.java
+++ b/src/main/java/org/cip4/lib/xjdf/type/Rectangle.java
@@ -1,5 +1,7 @@
 package org.cip4.lib.xjdf.type;
 
+import java.util.Locale;
+
 /**
  * XML Attributes of type rectangle are used to describe rectangular locations on the page, Sheet or other printable
  * surface. A rectangle is represented as an array of four numbers — llx lly urx ury — specifying the lower-left x,
@@ -115,7 +117,7 @@ public class Rectangle extends AbstractXJdfType<String, Rectangle> {
         double ury = v.getUry();
 
         // process marshalling
-        return String.format("%s %s %s %s", llx, lly, urx, ury);
+        return String.format(Locale.US, "%s %s %s %s", llx, lly, urx, ury);
     }
 
     /**

--- a/src/main/java/org/cip4/lib/xjdf/type/Shape.java
+++ b/src/main/java/org/cip4/lib/xjdf/type/Shape.java
@@ -1,5 +1,7 @@
 package org.cip4.lib.xjdf.type;
 
+import java.util.Locale;
+
 /**
  * XML Attributes of type shape are used to describe a three dimensional box. A shape is represented as an array of
  * three (positive or zero) numbers — x y z —
@@ -118,7 +120,7 @@ public class Shape extends AbstractXJdfType<String, Shape> {
         double z = shape.getZ();
 
         // create string
-        return String.format("%s %s %s", x, y, z);
+        return String.format(Locale.US, "%s %s %s", x, y, z);
     }
 
     /**

--- a/src/main/java/org/cip4/lib/xjdf/type/XYPair.java
+++ b/src/main/java/org/cip4/lib/xjdf/type/XYPair.java
@@ -1,6 +1,8 @@
 package org.cip4.lib.xjdf.type;
 
 
+import java.util.Locale;
+
 /**
  * XML Attributes of type XYPair are used to describe sizes like Dimensions and StartPosition. They can also be used to
  * describe positions on a page. All
@@ -80,7 +82,7 @@ public class XYPair extends AbstractXJdfType<String, XYPair> {
         double x = xyPair.getX();
         double y = xyPair.getY();
 
-        return String.format("%s %s", x, y);
+        return String.format(Locale.US, "%s %s", x, y);
     }
 
     /**

--- a/src/main/resources/binding.xjb
+++ b/src/main/resources/binding.xjb
@@ -143,7 +143,7 @@
     </xjb:bindings>
     <xjb:bindings node="//xs:element[@name='DropItem']//xs:attribute[@name='ItemRef']">
         <xjb:property name="item">
-            <xjb:baseType name="org.cip4.lib.xjdf.schema.Resource"/>
+            <xjb:baseType name="java.lang.Object"/>
         </xjb:property>
     </xjb:bindings>
     <xjb:bindings node="//xs:element[@name='Glue']//xs:attribute[@name='GlueRef']">


### PR DESCRIPTION
ItemRefs at DropItems are currently bound to XJDF **Resource** elements. When the XJDF contains a reference for a Product element, the library does not resolve the reference properly and discards the ItemRef completely while parsing.

### This MR contains the following changes:

Do not restrict the **DropItems** ItemRefs to an XJDF **Resource** element. Use generic base type in JAXB-Binding instead, so we can reference/resolve other instances like Products or ProofItems as well.

- Changed JAXB-Binding to generic Object-Type
- Updated build gradle file, so we can build a 0.15 release today
- Use US Locale when handling doubles ("." instead of ",")